### PR TITLE
ModelSpecificDistanceCalculator warning

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,8 @@
     <uses-sdk
         android:minSdkVersion="17"
         android:targetSdkVersion="19" />
+        
+    <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.BLUETOOTH"/>
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"/>
 


### PR DESCRIPTION
Updated to prevent ModelSpecificDistanceCalculator warning.

```
W/ModelSpecificDistanceCalculator﹕ App has no android.permission.INTERNET permission.  Cannot check for distance model updates
```