### PR TITLE
Support compile source code of beacon library

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,6 +20,6 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:28.0.0'
-    //compile project(':android-beacon-library')
-    compile 'org.altbeacon:android-beacon-library:2.15.4'
+    compile project(':android-beacon-library:lib')
+//    compile 'org.altbeacon:android-beacon-library:2.15.4'
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,3 @@
-//include ':android-beacon-library'
+include ':android-beacon-library:lib'
 include ':app'
 


### PR DESCRIPTION
Support compile source code of beacon library with the assumption that there is a symlinks pointing to the source code. 
The command that I used to create the link on Mac is
```ln -s /Users/ztang/beacon/android-beacon-library /Users/ztang/beacon/android-beacon-library-reference```