### PR TITLE
Modernize behavior on background detection

### DIFF
--- a/app/src/main/java/org/altbeacon/beaconreference/BeaconReferenceApplication.java
+++ b/app/src/main/java/org/altbeacon/beaconreference/BeaconReferenceApplication.java
@@ -115,17 +115,14 @@ public class BeaconReferenceApplication extends Application implements Bootstrap
     @Override
     public void didEnterRegion(Region arg0) {
         Log.d(TAG, "did enter region.");
-        // In this example, this class sends a notification to the user whenever a Beacon
+        // Send a notification to the user whenever a Beacon
         // matching a Region (defined above) are first seen.
+        Log.d(TAG, "Sending notification.");
+        sendNotification();
         if (monitoringActivity != null) {
             // If the Monitoring Activity is visible, we log info about the beacons we have
             // seen on its display
             logToDisplay("I see a beacon again" );
-        } else {
-            // The monitoring activity is not in
-            // the foreground, we send a notification to the user on subsequent detections.
-            Log.d(TAG, "Sending notification.");
-            sendNotification();
         }
     }
 


### PR DESCRIPTION
This modernizes the reference app to work properly with Android O+ on background detections.

While the Android Beacon Library has always supported the latest Android versions for background detections, this reference app has not always been updated to demonstrate the library behaviors in the newest Android versions.  This change corrects that in two ways:

1. It uses Notification Channels properly so that notifications appear on devices with Android O and higher.
2. It no longer tires to auto-launch an activity from the background on first-time beacon detection as this is no longer possible as of Android O.

The new background behavior is that it will send a notification whenever we enter the beacon region.  Tapping on that notification will launch the app UI.

If you wan to test a fast detection in the background, try this:

1. Run this app.  
2. Turn on a beacon so you get a region entry
3. Turn off a beacon and wait to get a region exit
4. Kill the app
5. Turn on the beacon, and watch for a quick notification!


